### PR TITLE
Update Go2PhpListener.php

### DIFF
--- a/src/Listener/Go2PhpListener.php
+++ b/src/Listener/Go2PhpListener.php
@@ -66,8 +66,11 @@ class Go2PhpListener implements ListenerInterface
             }
             $addr = $addrArr[$event->workerId];
         }
-        $server = make(SocketIPCReceiver::class, [$addr]);
-        $server->start();
+
+        go(function ()use ($addr){
+            $server = make(SocketIPCReceiver::class, [$addr]);
+            $server->start();
+        });
     }
 
     private function isUnix(string $addr): bool


### PR DESCRIPTION
修复在特殊情况下 开启Go2Php 会导致 HTTP 服务器无法正常启动